### PR TITLE
openvpn: fix uci-defaults script (#5103)

### DIFF
--- a/package/lean/luci-app-openvpn-server/root/etc/uci-defaults/openvpn
+++ b/package/lean/luci-app-openvpn-server/root/etc/uci-defaults/openvpn
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+openvpn_port="$(uci -q get openvpn.myvpn.port)"
+[ -z "$openvpn_port" ] && openvpn_port=1194
+
 uci -q batch <<-EOF >/dev/null
 	delete network.vpn0
 	set network.vpn0=interface
@@ -14,7 +17,7 @@ uci -q batch <<-EOF >/dev/null
 	set firewall.openvpn.target='ACCEPT'
 	set firewall.openvpn.src='wan'
 	set firewall.openvpn.proto='tcp udp'
-	set firewall.openvpn.dest_port='1194'
+	set firewall.openvpn.dest_port="$openvpn_port"
 
 	delete firewall.vpn
 	set firewall.vpn=zone


### PR DESCRIPTION
修复防火墙端口号。用户如果设置自定义端口，例如1197，则升级固件时，需要uci查询用户设定的自定义端口号，然后打开防火墙端口。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
